### PR TITLE
Fixed ArgumentOutOfRange Exception in after merge #9

### DIFF
--- a/YoutubeSearch/YoutubeSearch/VideoItemHelper.cs
+++ b/YoutubeSearch/YoutubeSearch/VideoItemHelper.cs
@@ -26,12 +26,11 @@ namespace YoutubeSearch
                 Start = strSource.IndexOf(strStart, 0) + strStart.Length;
                 End = strSource.IndexOf(strEnd, Start);
 
-                return strSource.Substring(Start, End - Start);
+                if(End>=Start)
+                    return strSource.Substring(Start, End - Start);
             }
-            else
-            {
-                return "";
-            }
+
+            return "";
         }
     }
 }


### PR DESCRIPTION
Merge #9  changed this code, to get the author information under more circumstances:
``` c#
if (string.IsNullOrEmpty(author))
author = VideoItemHelper.cull(result[ctr].Value, " >", "</a>");
```
However, there's the possibility, that a search request returns a string wich includes </a> and > in a way, that the cull of the helper function would throw an ArgumentOutOfRange, because the `strEnd` was located infront of `strStart`.

I added a simple if condition, to check for this
```c#
if(End>=Start)
return strSource.Substring(Start, End - Start);
```