### PR TITLE
Added optional offset for query

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ string querystring = "test";
 // Number of result pages
 int querypages = 1;
 
+// Offset value for querypages
+int querypagesOffset = 2;
+
 var items = new VideoSearch();
 
 foreach (var item in items.SearchQuery(querystring, querypages))
@@ -31,6 +34,9 @@ foreach (var item in items.SearchQuery(querystring, querypages))
 
 //For asynchronous execution use:
 var result = await items.SearchQueryAsync(querystring, querypages);
+
+//This will query from page 3 to 4
+var offsetResult = items.SearchQuery(querystring, querypages, querypagesOffset);
 ```
 
 # Supported Items

--- a/YoutubeSearch/Example Application/Program.cs
+++ b/YoutubeSearch/Example Application/Program.cs
@@ -44,11 +44,11 @@ namespace Example_Application
             //see difference of sync and async
             SyncQuery();
             AsyncQuery();
+            OffsetQuery();
 
 
             Console.ReadLine();
-        }
-
+        }    
 
         //example for synchronous execution
         private static void SyncQuery()
@@ -79,6 +79,30 @@ namespace Example_Application
                 Console.WriteLine(item.Title);
                 Console.WriteLine("");
             }
+        }
+
+        //example for using the offset value
+        private static async void OffsetQuery()
+        {
+            //this function will return all results from page 1 to page 10
+            var querystring = "test";
+            int querypages = 1;
+            int querypagesOffset;
+
+            //create list and search
+            var pages = new List<List<VideoInformation>>();
+            var items = new VideoSearch();
+
+            for (int i = 0; i < 10; i++)
+            {
+                //increase offset
+                querypagesOffset = i;
+
+                //each iteration will return the next page
+                //useful, if pages are needed in a sequence, in order to reduce waiting time
+                pages.Add(items.SearchQuery(querystring, querypages, querypagesOffset));
+            }
+            //page 1-10 (index in list 0-9) is now stored in 'pages'
         }
     }
 }

--- a/YoutubeSearch/YoutubeSearch/VideoSearch.cs
+++ b/YoutubeSearch/YoutubeSearch/VideoSearch.cs
@@ -28,7 +28,9 @@ namespace YoutubeSearch
     public class VideoSearch
     {
         //constants for easier maintainability
-        private const string Pattern = "<div class=\"yt-lockup-content\">.*?title=\"(?<NAME>.*?)\".*?</div></div></div></li>";
+        private const string Pattern =
+            "<div class=\"yt-lockup-content\">.*?title=\"(?<NAME>.*?)\".*?</div></div></div></li>";
+
         private const string YtQueryUrl = "https://www.youtube.com/results?search_query=";
         private const string YtThumbnailUrl = "https://i.ytimg.com/vi/";
         private const string YtWatchUrl = "http://www.youtube.com/watch?v=";
@@ -38,30 +40,37 @@ namespace YoutubeSearch
 
         WebClient webclient;
 
-	string title;
-	string author;
-	string description;
-	string duration;
-	string url;
-	string thumbnail;
-	string viewCount;
-	bool noDesc = false;
-	bool noAuthor = false;
+        string title;
+        string author;
+        string description;
+        string duration;
+        string url;
+        string thumbnail;
+        string viewCount;
+        bool noDesc = false;
+        bool noAuthor = false;
 
         /// <summary>
-        /// Doing search query with given parameters. Returns a List<> object.
+        /// Doing asynchronous search query with given parameters. Returns a List object.
         /// </summary>
         /// <param name="querystring"></param>
-        /// <param name="querypages"></param>
+        /// <param name="querypages">number of pages to query</param>
+        /// <param name="querypagesOffset">offset for querypages</param>
         /// <returns></returns>
-        public async Task<List<VideoInformation>> SearchQueryTaskAsync(string querystring, int querypages)
+        public async Task<List<VideoInformation>> SearchQueryTaskAsync(string querystring, int querypages,
+            int querypagesOffset = 0)
         {
+            //negative index not allowed
+            if (querypagesOffset < 0)
+                querypagesOffset = 0;
+
+
             items = new List<VideoInformation>();
 
             webclient = new WebClient();
 
-            // Do search
-            for (int i = 1; i <= querypages; i++)
+            // Do search, regarding offset
+            for (int i = (1 + querypagesOffset); i <= (querypages + querypagesOffset); i++)
             {
                 // Search address
                 string html = await webclient.DownloadStringTaskAsync(YtQueryUrl + querystring + "&page=" + i);
@@ -74,19 +83,24 @@ namespace YoutubeSearch
         }
 
         /// <summary>
-        /// Doing search query with given parameters. Returns a List<> object.
+        /// Doing search query with given parameters. Returns a List object.
         /// </summary>
         /// <param name="querystring"></param>
-        /// <param name="querypages"></param>
+        /// <param name="querypages">number of pages to query</param>
+        /// <param name="querypagesOffset">offset for querypages</param>
         /// <returns></returns>
-        public List<VideoInformation> SearchQuery(string querystring, int querypages)
+        public List<VideoInformation> SearchQuery(string querystring, int querypages, int querypagesOffset = 0)
         {
+            //negative index not allowed
+            if (querypagesOffset < 0)
+                querypagesOffset = 0;
+
             items = new List<VideoInformation>();
 
             webclient = new WebClient();
 
-            // Do search
-            for (int i = 1; i <= querypages; i++)
+            // Do search, regarding offset
+            for (int i = (1 + querypagesOffset); i <= (querypages + querypagesOffset); i++)
             {
                 // Search address
                 string html = webclient.DownloadString(YtQueryUrl + querystring + "&page=" + i);
@@ -101,70 +115,80 @@ namespace YoutubeSearch
 
         private void ProcessPage(string htmlPage)
         {
-           
             MatchCollection result = Regex.Matches(htmlPage, Pattern, RegexOptions.Singleline);
 
             for (int ctr = 0; ctr <= result.Count - 1; ctr++)
             {
-		if (result[ctr].Value.Contains("yt-uix-button-subscription-container\">") || result[ctr].Value.Contains("\"instream\":true"))
-			continue; // Don't add to the list of search results if the value is a channel or live stream.
-		    
+                if (result[ctr].Value.Contains("yt-uix-button-subscription-container\">") ||
+                    result[ctr].Value.Contains("\"instream\":true"))
+                    continue; // Don't add to the list of search results if the value is a channel or live stream.
+
                 // Title
                 title = result[ctr].Groups[1].Value;
 
                 // Author
-		author = VideoItemHelper.cull(result[ctr].Value, "/user/", "class").Replace('"', ' ').TrimStart().TrimEnd();
-		if (string.IsNullOrEmpty(author))
-		{
-			author = VideoItemHelper.cull(result[ctr].Value, " >", "</a>");
-			if (string.IsNullOrEmpty(author))
-				noAuthor = true;
-		}
+                author = VideoItemHelper.cull(result[ctr].Value, "/user/", "class").Replace('"', ' ').TrimStart()
+                    .TrimEnd();
+                if (string.IsNullOrEmpty(author))
+                {
+                    author = VideoItemHelper.cull(result[ctr].Value, " >", "</a>");
+                    if (string.IsNullOrEmpty(author))
+                        noAuthor = true;
+                }
 
                 // Description
-		description = VideoItemHelper.cull(result[ctr].Value, "dir=\"ltr\" class=\"yt-uix-redirect-link\">", "</div>");
-		if (string.IsNullOrEmpty(description))
-		{
-			description = VideoItemHelper.cull(result[ctr].Value, "<div class=\"yt-lockup-description yt-ui-ellipsis yt-ui-ellipsis-2\" dir=\"ltr\">", "</div>");
-			if (string.IsNullOrEmpty(description))
-				noDesc = true;
-		}
-		    
-		// Duration
-		duration = VideoItemHelper.cull(VideoItemHelper.cull(result[ctr].Value, "id=\"description-id-", "span"), ": ", "<").Replace(".", "");
-		    
+                description = VideoItemHelper.cull(result[ctr].Value, "dir=\"ltr\" class=\"yt-uix-redirect-link\">",
+                    "</div>");
+                if (string.IsNullOrEmpty(description))
+                {
+                    description = VideoItemHelper.cull(result[ctr].Value,
+                        "<div class=\"yt-lockup-description yt-ui-ellipsis yt-ui-ellipsis-2\" dir=\"ltr\">", "</div>");
+                    if (string.IsNullOrEmpty(description))
+                        noDesc = true;
+                }
+
+                // Duration
+                duration = VideoItemHelper
+                    .cull(VideoItemHelper.cull(result[ctr].Value, "id=\"description-id-", "span"), ": ", "<")
+                    .Replace(".", "");
+
                 // Url
                 url = string.Concat(YtWatchUrl, VideoItemHelper.cull(result[ctr].Value, "watch?v=", "\""));
 
                 // Thumbnail
-                thumbnail = YtThumbnailUrl + VideoItemHelper.cull(result[ctr].Value, "watch?v=", "\"") + "/mqdefault.jpg";
-		    
-		// View Count
-		{
-			string strView = VideoItemHelper.cull(result[ctr].Value, "</li><li>", "</li></ul></div>");
-			if (!string.IsNullOrEmpty(strView) && !string.IsNullOrWhiteSpace(strView))
-			{
-				string[] strParsedArr = strView.Split(new string[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                thumbnail = YtThumbnailUrl + VideoItemHelper.cull(result[ctr].Value, "watch?v=", "\"") +
+                            "/mqdefault.jpg";
 
-				string parsedText = strParsedArr[0];
-				parsedText = parsedText.Trim().Replace(",", ".");
+                // View Count
+                {
+                    string strView = VideoItemHelper.cull(result[ctr].Value, "</li><li>", "</li></ul></div>");
+                    if (!string.IsNullOrEmpty(strView) && !string.IsNullOrWhiteSpace(strView))
+                    {
+                        string[] strParsedArr =
+                            strView.Split(new string[] {" "}, StringSplitOptions.RemoveEmptyEntries);
 
-				viewCount = parsedText;
-			}
-		}
-		    
-		// Remove playlists
-		if (title != "__title__" && duration != "")
-		{
-			// Add item to list
-			items.Add(new VideoInformation() { Title = title, Author = author, Description = description, Duration = duration, Url = url, Thumbnail = thumbnail, NoAuthor = noAuthor, NoDescription = noDesc, ViewCount = viewCount });
-		}
-		    
-		// Reset values to default for next loop.
-		noAuthor = false;
-		noDesc = false;
+                        string parsedText = strParsedArr[0];
+                        parsedText = parsedText.Trim().Replace(",", ".");
+
+                        viewCount = parsedText;
+                    }
+                }
+
+                // Remove playlists
+                if (title != "__title__" && duration != "")
+                {
+                    // Add item to list
+                    items.Add(new VideoInformation()
+                    {
+                        Title = title, Author = author, Description = description, Duration = duration, Url = url,
+                        Thumbnail = thumbnail, NoAuthor = noAuthor, NoDescription = noDesc, ViewCount = viewCount
+                    });
+                }
+
+                // Reset values to default for next loop.
+                noAuthor = false;
+                noDesc = false;
             }
         }
-
     }
 }


### PR DESCRIPTION
I added a optional parameter ```int querypagesOffset```. 

The offset will cause the Youtube-Query to start its search with the specified offset.

If you feed in ```querypages=5``` it will return pages 1 to 5.
If you now add ```querypagesOffset=5``` it will return (1+5) to (5+5).

The most important thing, it's backwards compatible, as the default value ```=0``` won't change anything compared to previous versions.

I also ajdusted the Readme and the example application 
and I executed resharpers code formatting on the source file ```VideoSearch.cs```.

