### PR TITLE
Encoding based on users choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ int querypagesOffset = 2;
 
 var items = new VideoSearch();
 
+//change the encoding, using Encoding.Default if not set
+items.encoding = Encoding.UTF8; 
+
 foreach (var item in items.SearchQuery(querystring, querypages))
 {
     Console.WriteLine(item.Title);

--- a/YoutubeSearch/Example Application/Program.cs
+++ b/YoutubeSearch/Example Application/Program.cs
@@ -24,6 +24,10 @@ namespace Example_Application
 
             var items = new VideoSearch();
 
+            //specify the encoding for this object
+            items.encoding = Encoding.UTF8;
+            
+
             int i = 1;
 
             foreach (var item in items.SearchQuery(querystring, querypages))

--- a/YoutubeSearch/YoutubeSearch/VideoSearch.cs
+++ b/YoutubeSearch/YoutubeSearch/VideoSearch.cs
@@ -22,6 +22,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.IO;
 using System;
+using System.Text;
 
 namespace YoutubeSearch
 {
@@ -34,6 +35,12 @@ namespace YoutubeSearch
         private const string YtQueryUrl = "https://www.youtube.com/results?search_query=";
         private const string YtThumbnailUrl = "https://i.ytimg.com/vi/";
         private const string YtWatchUrl = "http://www.youtube.com/watch?v=";
+
+
+        /// <summary>
+        /// Specify the used encoding. Recommended: ASCII, UTF-8
+        /// </summary>
+        public Encoding encoding = Encoding.Default;
 
 
         List<VideoInformation> items;
@@ -68,6 +75,7 @@ namespace YoutubeSearch
             items = new List<VideoInformation>();
 
             webclient = new WebClient();
+            webclient.Encoding = encoding;
 
             // Do search, regarding offset
             for (int i = (1 + querypagesOffset); i <= (querypages + querypagesOffset); i++)
@@ -98,6 +106,7 @@ namespace YoutubeSearch
             items = new List<VideoInformation>();
 
             webclient = new WebClient();
+            webclient.Encoding = encoding;
 
             // Do search, regarding offset
             for (int i = (1 + querypagesOffset); i <= (querypages + querypagesOffset); i++)


### PR DESCRIPTION
Added public encoding field to VideSearch (#18).

Working types are ```Encoding.ASCII``` and ```Encoding.UTF8```. Other encodings are not forbidden, as they could be useful on some other languages.

The value is set the same as for the ```Webclient()```
```new VideSearch(){encoding = Encoding.UTF8};```

If nothing is specified, it will use Encoding.Default.

Added a line to the readme and example projects aswell.
